### PR TITLE
Update Property Interfaces and Localize "Getting Started" Titles

### DIFF
--- a/docs/modules/color-guide/ts/views/index.tsx
+++ b/docs/modules/color-guide/ts/views/index.tsx
@@ -4,8 +4,7 @@ import MaterialDesign from './es/material-design.mdx';
 export /*bundle*/
 function View() {
 	return (
-		<div className='page__container'>
-			<h2>Color system</h2>
+		<div className="page__container">
 			<Docs />
 			<h2>Material Design</h2>
 			<MaterialDesign />

--- a/docs/modules/getting-started/installation/ts/views/index.tsx
+++ b/docs/modules/getting-started/installation/ts/views/index.tsx
@@ -1,28 +1,25 @@
-import * as React from "react";
-import { Code } from "pragmate-ui/code";
-import { implementationsButton } from "../implementation";
+import * as React from 'react';
+import { Code } from 'pragmate-ui/code';
+import { implementationsButton } from '../implementation';
 export /*bundle*/
 function View() {
-  return (
-    <div className="view view-installation">
-      <h1 className="view__h1">Installation</h1>
-      <h3 className="view__h3">
-        instalacion de <strong className="view__strong">PragmateUI</strong>
-      </h3>
-      <p className="view__p">
-        Como ya se dijo la instalacion de{" "}
-        <strong className="view__strong">PragmateUI</strong> es sencilla,
-        debemos ejecutar el siguiente comando en el paquete que deseemos usarlo:
-      </p>
-      <Code>{`npm i @pragmate/ui `}</Code>
-      <p className="view__p">
-        Una vez hecho ya podremos beneficiarnos y contar con todas las
-        herramientas que ofrece{" "}
-        <strong className="view__strong">PragmateUI</strong>. Implemente y
-        trabaje de manera sencilla con todos las herramientas y uselos segun su
-        necesidad.
-      </p>
-      <Code>{implementationsButton}</Code>
-    </div>
-  );
+	return (
+		<div className="view view-installation">
+			<h1 className="view__h1">Instalacion</h1>
+			<h3 className="view__h3">
+				instalacion de <strong className="view__strong">PragmateUI</strong>
+			</h3>
+			<p className="view__p">
+				Como ya se dijo la instalacion de <strong className="view__strong">PragmateUI</strong> es sencilla,
+				debemos ejecutar el siguiente comando en el paquete que deseemos usarlo:
+			</p>
+			<Code>{`npm i @pragmate/ui `}</Code>
+			<p className="view__p">
+				Una vez hecho ya podremos beneficiarnos y contar con todas las herramientas que ofrece{' '}
+				<strong className="view__strong">PragmateUI</strong>. Implemente y trabaje de manera sencilla con todos
+				las herramientas y uselos segun su necesidad.
+			</p>
+			<Code>{implementationsButton}</Code>
+		</div>
+	);
 }

--- a/docs/modules/getting-started/introduction/ts/views/index.tsx
+++ b/docs/modules/getting-started/introduction/ts/views/index.tsx
@@ -1,50 +1,50 @@
 import * as React from 'react';
-
 import { Link, Button } from 'pragmate-ui/components';
+
 export /*bundle*/
 function View() {
 	return (
-		<div className='view view-introduction'>
-			<h1 className='view__h1'>Introducction</h1>
-			<p className='view__p'>
-				¡Bienvenido a la documentación de <strong className='view__strong'>PragmateUI</strong>!
+		<div className="view view-introduction">
+			<h1 className="view__h1">Introduccion</h1>
+			<p className="view__p">
+				¡Bienvenido a la documentación de <strong className="view__strong">PragmateUI</strong>!
 			</p>
-			<p className='view__p'>
+			<p className="view__p">
 				PragmateUI es una libreria que provee componentes reutilizables, rapidos y dinamicos para su pagina o
 				aplicacion web ! Creado principalmente con{' '}
-				<strong className='view__strong strong-beyondjs'>
+				<strong className="view__strong strong-beyondjs">
 					{' '}
-					<Link href='https://beyondjs.com'>BeyondJS</Link>
+					<Link href="https://beyondjs.com">BeyondJS</Link>
 				</strong>
 				.
 			</p>
 
-			<h3 className='view__h3'>
-				¿Por que <strong className='view__strong'>Pragmate UI</strong>?
+			<h3 className="view__h3">
+				¿Por que <strong className="view__strong">Pragmate UI</strong>?
 			</h3>
-			<p className='view__p'>
+			<p className="view__p">
 				La idea principal es por su uso tan sencillo y adaptable de componentes reutilizables que permite que
 				usted o su equipo ahorre tiempo mediante el uso de componentes preconstruidos, modulares y atractivos.
 				Tambien una de las buenas cosas es por la gran variedad de componentes que ofrece{' '}
-				<strong className='view__strong'>Pragmate UI</strong>, desde botones hasta drag and drolls. Esta
+				<strong className="view__strong">Pragmate UI</strong>, desde botones hasta drag and drolls. Esta
 				libreria incluye una variedad de componentes que se pueden importar e implementar fácilmente en su
 				proyecto.
 			</p>
 
-			<h3 className='view__h3'>Configuracion previa</h3>
-			<p className='view__p'>
-				¡No hay! trabajar con <strong className='view__strong'>Pragmate UI</strong> es sencillo y no requiere de
+			<h3 className="view__h3">Configuracion previa</h3>
+			<p className="view__p">
+				¡No hay! trabajar con <strong className="view__strong">Pragmate UI</strong> es sencillo y no requiere de
 				una implementacion previa en su proyecto. Solamente hacer bien la instalacion de la libreria.
 			</p>
-			<h3 className='view__h3'>Apoyanos</h3>
-			<p className='view__p'>
+			<h3 className="view__h3">Apoyanos</h3>
+			<p className="view__p">
 				Si desea apoyarnos colaborando con nosotros en la creacion de componentes o mejora de alguno de estos le
-				dejamos nuestro <strong className='view__strong'>Github</strong>.👇
+				dejamos nuestro <strong className="view__strong">Github</strong>.👇
 			</p>
-			<Button variant='primary' icon='paperPlane' className='icon--right'>
-				<Link href='https://github.com/balearesg/pragmate-ui'>Github</Link>
+			<Button variant="primary" icon="paperPlane" className="icon--right">
+				<Link href="https://github.com/balearesg/pragmate-ui">Github</Link>
 			</Button>
-			<img src='' alt='' />
+			<img src="" alt="" />
 		</div>
 	);
 }

--- a/docs/modules/layouts/docs/ts/bg.getting-started.ts
+++ b/docs/modules/layouts/docs/ts/bg.getting-started.ts
@@ -1,5 +1,5 @@
 export const gettingStartedItems = [
-  ["Introduction", "introduction", []],
-  ["Installation", "installation", []],
-  ["Color Guide", "color-guide", []],
+	['Introduction', 'introduction', []],
+	['Instalacion', 'installation', []],
+	['Guia de colores', 'color-guide', []],
 ];

--- a/project/modules/alert/ts/alert.tsx
+++ b/project/modules/alert/ts/alert.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Icon, IconButton } from 'pragmate-ui/icons';
 import { Content } from './content';
-import { IProps, IiconMap } from './types';
+import { IProps, IIconMap } from './types';
 
 export /*bundle*/
 function Alert(props: IProps) {
@@ -20,7 +20,7 @@ function Alert(props: IProps) {
 	let cls = `${className ? `${className} ` : ''} alert${type ? ` alert--${type}` : ''}`;
 	cls = icon ? `${cls} alert--icon` : cls;
 
-	const icons: IiconMap = {
+	const icons: IIconMap = {
 		error: 'error',
 		warning: 'circle-exclamation',
 		success: 'circle-check',
@@ -40,7 +40,7 @@ function Alert(props: IProps) {
 			<Content message={message} type={type} title={title} icon={hasIcon}>
 				{children}
 			</Content>
-			{closable && <IconButton icon='close' onClick={onCloseClick} />}
+			{closable && <IconButton icon="close" onClick={onCloseClick} />}
 		</div>
 	);
 }

--- a/project/modules/alert/ts/types.ts
+++ b/project/modules/alert/ts/types.ts
@@ -10,6 +10,6 @@ export interface IProps {
 	icon?: boolean | string;
 }
 
-export type IiconMap = {
+export interface IIconMap {
 	[key: string]: string;
-};
+}

--- a/project/modules/tabs/original/ts/tabs.tsx
+++ b/project/modules/tabs/original/ts/tabs.tsx
@@ -3,8 +3,8 @@ import { useState, PropsWithChildren } from 'react';
 import { useTabsContext } from './context';
 import { Tab } from './tab';
 import { routing } from '@beyond-js/kernel/routing';
-import { Iprops, Iproperties } from './types';
-export /*bundle*/ function Tabs(props: PropsWithChildren<Iprops>): JSX.Element {
+import { IProps, IProperties } from './types';
+export /*bundle*/ function Tabs(props: PropsWithChildren<IProps>): JSX.Element {
 	const [state, setState] = useState({
 		active: true,
 		valueSelected: 0,
@@ -32,7 +32,7 @@ export /*bundle*/ function Tabs(props: PropsWithChildren<Iprops>): JSX.Element {
 	const { active, valueSelected } = state;
 
 	const output = children.map((tab, index) => {
-		const properties: Iproperties = {
+		const properties: IProperties = {
 			key: index,
 			selected: selected,
 			isActive: active,
@@ -56,8 +56,8 @@ export /*bundle*/ function Tabs(props: PropsWithChildren<Iprops>): JSX.Element {
 	});
 
 	return (
-		<div className='pui-tabs-items'>
-			<div className='tabs-container'>{output}</div>
+		<div className="pui-tabs-items">
+			<div className="tabs-container">{output}</div>
 		</div>
 	);
 }

--- a/project/modules/tabs/original/ts/types.ts
+++ b/project/modules/tabs/original/ts/types.ts
@@ -1,11 +1,11 @@
-export type Iprops = {
+export interface IProps {
 	onClick?: any;
 	children?: any;
 	nolink?: any;
 	selected?: any;
-};
+}
 
-export interface Iproperties {
+export interface IProperties {
 	key?: number;
 	selected?: string;
 	isActive?: boolean;

--- a/project/modules/tabs/tabs/ts/index.tsx
+++ b/project/modules/tabs/tabs/ts/index.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import { TabsContext } from './context';
 import { ITabProps } from './interfaces';
 
-const { useState } = React;
-
 export /* bundle  */ const TabsContainer: React.FC<ITabProps> = ({ active, onChange, children, panes }) => {
 	const activeIndex = active || 0;
-	const [activeTab, setActiveTab] = useState(activeIndex);
+	const [activeTab, setActiveTab] = React.useState(activeIndex);
 	const value = { panes, activeTab, setActiveTab, onChange };
 
 	return (

--- a/project/modules/tabs/tabs/ts/interfaces.ts
+++ b/project/modules/tabs/tabs/ts/interfaces.ts
@@ -1,12 +1,12 @@
-export type TPane = {
+export interface ITPane {
 	tab: string;
 	content: React.ReactNode;
-};
+}
 
-export type ITabProps = {
-	panes: TPane[];
+export interface ITabProps {
+	panes: ITPane[];
 	children: React.ReactNode;
 	active?: number;
 	setURL?: boolean;
 	onChange?: (event, index) => void;
-};
+}

--- a/trash/drag-and-drop/code/ts/index.tsx
+++ b/trash/drag-and-drop/code/ts/index.tsx
@@ -1,10 +1,10 @@
 import React, { useRef, useEffect, MutableRefObject, PropsWithChildren, useReducer } from 'react';
 import { DragAndDropContext } from './context';
 import { initialState, reducer } from './reducer';
-import { CValue, propsIndex } from './types';
+import { CValue, IPropsIndex } from './types';
 import { View } from './view';
 
-export /*bundle*/ const DragAndDrop = (props: PropsWithChildren<propsIndex>): JSX.Element => {
+export /*bundle*/ const DragAndDrop = (props: PropsWithChildren<IPropsIndex>) => {
 	const drop: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
 
 	const [state, dispatch] = useReducer(reducer, initialState);

--- a/trash/drag-and-drop/code/ts/reducer.ts
+++ b/trash/drag-and-drop/code/ts/reducer.ts
@@ -1,57 +1,57 @@
-import { InitialState, Payload } from "./types";
+import { InitialState, IPayload } from './types';
 
-export const reducer = (state: InitialState, payload: Payload): InitialState => {
-    switch (payload.case) {
-        case "dragging": {
-            return {
-                ...state,
-                dragging: payload.dragging
-            };
-        };
-        case "files": {
-            return {
-                ...state,
-                files: payload.files
-            };
-        };
-        case "message": {
-            return {
-                ...state,
-                message: {
-                    show: payload.show,
-                    text: payload.text,
-                    type: payload.type,
-                }
-            }
-        };
-        case "hideMessage": {
-            return {
-                ...state,
-                message: {
-                    show: false,
-                    text: null,
-                    type: null,
-                }
-            }
-        };
-        case "img": {
-            return {
-                ...state,
-                img: payload.img
-            }
-        };
-        default:
-            return;
-    };
+export const reducer = (state: InitialState, payload: IPayload): InitialState => {
+	switch (payload.case) {
+		case 'dragging': {
+			return {
+				...state,
+				dragging: payload.dragging,
+			};
+		}
+		case 'files': {
+			return {
+				...state,
+				files: payload.files,
+			};
+		}
+		case 'message': {
+			return {
+				...state,
+				message: {
+					show: payload.show,
+					text: payload.text,
+					type: payload.type,
+				},
+			};
+		}
+		case 'hideMessage': {
+			return {
+				...state,
+				message: {
+					show: false,
+					text: null,
+					type: null,
+				},
+			};
+		}
+		case 'img': {
+			return {
+				...state,
+				img: payload.img,
+			};
+		}
+		default:
+			return;
+	}
 };
 
 export const initialState: InitialState = {
-    dragging: false,
-    files: [],
-    message: {
-        show: false,
-        text: null,
-        type: null,
-    },
-    img: "",
+	dragging: false,
+	files: [],
+	message: {
+		show: false,
+		text: null,
+		type: null,
+	},
+	img: '',
 };

--- a/trash/drag-and-drop/code/ts/types.ts
+++ b/trash/drag-and-drop/code/ts/types.ts
@@ -1,49 +1,49 @@
 import { Dispatch, MutableRefObject } from 'react';
 
-export type propsIndex = {
-    count?: number;
-    formats?: string[];
-    onUpload: (files: File[]) => void;
-    clean?: boolean;
-    userPhoto?: boolean;
-    textUserPhoto?: string;
-};
-
-type Message = {
-    show: boolean,
-    text: string | null,
-    type: string | null,
+export interface IPropsIndex {
+	count?: number;
+	formats?: string[];
+	onUpload: (files: File[]) => void;
+	clean?: boolean;
+	userPhoto?: boolean;
+	textUserPhoto?: string;
 }
 
-export interface InitialState {
-    dragging: boolean,
-    files: File[],
-    message: Message,
-    img: string
+type Message = {
+	show: boolean;
+	text: string | null;
+	type: string | null;
 };
 
-export type Payload = {
-    case: 'hideMessage' | 'message' | 'files' | 'dragging' | "img",
-    files?: File[],
-    dragging?: boolean,
-    show?: boolean,
-    text?: string | null,
-    type?: string | null,
-    img?: string
-};
+export interface InitialState {
+	dragging: boolean;
+	files: File[];
+	message: Message;
+	img: string;
+}
+
+export interface IPayload {
+	case: 'hideMessage' | 'message' | 'files' | 'dragging' | 'img';
+	files?: File[];
+	dragging?: boolean;
+	show?: boolean;
+	text?: string | null;
+	type?: string | null;
+	img?: string;
+}
 
 export interface CValue {
-    files: File[],
-    message?: Message,
-    count?: number,
-    formats?: string[],
-    showMessage?: (text: string, type: string, timeout: number) => void,
-    dispatch?: Dispatch<Payload>,
-    onUpload?: (files: File[]) => void,
-    state?: InitialState,
-    clean?: boolean,
-    drop?: MutableRefObject<HTMLDivElement>,
-    drag?: MutableRefObject<HTMLDivElement>,
-    userPhoto?: boolean;
-    textUserPhoto?: string
-};
+	files: File[];
+	message?: Message;
+	count?: number;
+	formats?: string[];
+	showMessage?: (text: string, type: string, timeout: number) => void;
+	dispatch?: Dispatch<IPayload>;
+	onUpload?: (files: File[]) => void;
+	state?: InitialState;
+	clean?: boolean;
+	drop?: MutableRefObject<HTMLDivElement>;
+	drag?: MutableRefObject<HTMLDivElement>;
+	userPhoto?: boolean;
+	textUserPhoto?: string;
+}


### PR DESCRIPTION
## Description

In this PR, we have made two distinct updates to our codebase. First, we embarked on a chore to identify and modify all types that should semantically be interfaces when related to properties. This aligns with best TypeScript practices, ensuring clarity and ease of understanding. Secondly, in a feature update, we've taken a step towards localization by translating the titles in our "Getting Started" section to Spanish.

#### Changes

- **Chore**: All types that correspond to property interfaces have been changed to actual interfaces.
- **Feature**: Titles in the "Getting Started" section have been translated to Spanish.

## Why these changes?

- **Consistency and Best Practices**: Transitioning types that are essentially property interfaces to actual interfaces in TypeScript helps in maintaining code consistency and following best coding practices.
- **Localization**: Changing titles to Spanish makes our documentation more accessible to our Spanish-speaking users, broadening our reach and ensuring inclusivity.

## How to Test

1. Navigate through the codebase and ensure that all relevant types have been changed to interfaces where it semantically makes sense.
2. Go to the "Getting Started" section and confirm that the titles are now in Spanish and make sense in the given context.