### PR TITLE
fixed switch

### DIFF
--- a/library/modules/form/controls/ts/switch.tsx
+++ b/library/modules/form/controls/ts/switch.tsx
@@ -7,7 +7,13 @@ interface IProps extends InputHTMLAttributes<HTMLInputElement> {
 
 export /* bundle */ function Switch(props: IProps): JSX.Element {
 	const { checked, onChange, variant = 'primary', disabled, size = 'md', className, } = props;
+
 	const [isChecked, setIsChecked] = React.useState<boolean>(checked);
+
+	React.useEffect(() => {
+		if (isChecked === checked) return;
+		setIsChecked(checked)
+	}, [checked])
 
 	const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
 		event.stopPropagation()


### PR DESCRIPTION
## Fixed switch
When the checked was changed externally, the swith was not updated since it was only done through the onChange event. Now, every time the props checked changes and it is not the same as the props checked, the latter is updated.