### PR TITLE
Fix(input): i include the type datetime-local betweent the input type to show

### DIFF
--- a/docs/modules/components/form/controls/input/ts/views/examples/date.tsx
+++ b/docs/modules/components/form/controls/input/ts/views/examples/date.tsx
@@ -18,6 +18,7 @@ export function Dates() {
                 <Input variant='floating' type='date' value="" />
                 <Input variant='floating' type='date' label='Type Date' icon="user" value="" />
                 <Input variant='floating' type='date' {...iconCalendar} value="" />
+                <Input variant='floating' type='datetime-local' icon="box" value="" />
 			</UIExample>
 		</>
 	);

--- a/src/modules/form/controls/ts/input/components/date.tsx
+++ b/src/modules/form/controls/ts/input/components/date.tsx
@@ -6,8 +6,9 @@ interface HTMLInputWithPicker extends HTMLInputElement {
 }
 
 export function Date(): JSX.Element {
-	const { input, props, icon } = useInputContext();
-	if (props.type !== 'date') return null;
+	const { input, props, icon, isDate } = useInputContext();
+
+	if (!isDate) return null;
 	const iconValue = icon ? icon : 'calendar';
 
 	const showPicker = () => {

--- a/src/modules/form/controls/ts/input/components/icon-container.tsx
+++ b/src/modules/form/controls/ts/input/components/icon-container.tsx
@@ -11,7 +11,8 @@ export function IconContainer(): JSX.Element {
         date: Date,
         default: null,
         month: Date,
-        week: Date
+        week: Date,
+        'datetime-local': Date
     };
     const output = [];
     if (!!types[props.type]) {
@@ -19,7 +20,7 @@ export function IconContainer(): JSX.Element {
         output.push(<Control key="control" />)
     };
 
-    if(props.type !== 'date' && !!props.icon) {
+    if(!!props.icon) {
         output.push(<Icon key="icon" />)
     }
     return <>{output}</>


### PR DESCRIPTION
Hi Team !

I come back again with another PR to add the datetime-local type in code to generate input, I overlooked this and as I am using it in a project where I am working I need the datetime-local input, as it is not adding it in the code you don't see any icon 

![image](https://github.com/balearesg/pragmate-ui/assets/111388958/fb8469cc-c8d6-4d97-b25e-f085710314ef)
