### PR TITLE
Fix: Added the ability to cover the case of multi value select while maintaining the API.

### DIFF
--- a/src/modules/common/icons/ts/pragmate-icon-button.tsx
+++ b/src/modules/common/icons/ts/pragmate-icon-button.tsx
@@ -84,12 +84,11 @@ const IconButton: React.FC<PropsWithChildren<props> & RefAttributes<HTMLButtonEl
 				disabled={disabled}
 				className={className}
 				onClick={onClickButton}
-				{...attrs}
-			>
+				{...attrs}>
 				<Icon {...iconAttributes} />
 				{children}
 				{/* {!disabled && <BeyondWaves/>} */}
 			</button>
 		);
-	},
+	}
 );

--- a/src/modules/form/react-select/ts/index.tsx
+++ b/src/modules/form/react-select/ts/index.tsx
@@ -36,24 +36,40 @@ function ReactSelect(props) {
 	}, []);
 
 	let value = props.options.find(item => item.value === props.value);
-	const onChange = ({ label, value }) => {
+	const onChange = params => {
 		if (!props.onChange) return;
+		const isMultiValues = properties?.isMulti;
+		if (!isMultiValues) {
+			props.onChange({
+				target: {
+					value,
+					name: props.name,
+				},
+				currentTarget: {
+					value,
+					name: props.name,
+				},
+			});
+			return;
+		}
+
+		const values = params.map(selectedItem => selectedItem.value);
 		props.onChange({
 			target: {
-				value,
+				value: values,
 				name: props.name,
 			},
 			currentTarget: {
-				value,
+				value: values,
 				name: props.name,
 			},
 		});
 	};
 
 	return (
-		<div className='pui-select' ref={ref}>
+		<div className="pui-select" ref={ref}>
 			{props.label && <label>{props.label}</label>}
-			<Select classNamePrefix='pui-react-select' onChange={onChange} {...properties} value={value} />
+			<Select classNamePrefix="pui-react-select" onChange={onChange} {...properties} value={value} />
 		</div>
 	);
 }

--- a/src/modules/form/react-select/ts/index.tsx
+++ b/src/modules/form/react-select/ts/index.tsx
@@ -35,7 +35,8 @@ function ReactSelect(props) {
 		return () => styleObserver.stopObserving();
 	}, []);
 
-	let value = props.options.find(item => item.value === props.value);
+	const singleValue = !properties.isMulti && props.options.find(item => item.value === props.value);
+	let value = properties.isMulti ? props.value : singleValue;
 	const onChange = params => {
 		if (!props.onChange) return;
 		const isMultiValues = properties?.isMulti;

--- a/src/modules/form/react-select/ts/index.tsx
+++ b/src/modules/form/react-select/ts/index.tsx
@@ -1,69 +1,30 @@
 import React from 'react';
 import Select from 'react-select';
-import { StyleObserver } from './observer';
+import { useStyles } from './use-styles';
 
 export /*bundle*/
 function ReactSelect(props) {
 	let properties = { ...props };
 	delete properties.onChange;
-	const ref = React.useRef(null);
-
-	React.useEffect(() => {
-		const host = ref.current.getRootNode()?.host;
-		if (!host) {
-			console.warn('is not inside a web component');
-		}
-		const headStyles = document.head.querySelectorAll('style[data-emotion]');
-
-		const insert = (nodes: HTMLElement[] | NodeList) => {
-			nodes.forEach(node => {
-				if (node instanceof HTMLStyleElement) {
-					// Handle the new style element
-					const clonedStyle = node.cloneNode(true) as HTMLElement;
-					host.shadowRoot.appendChild(clonedStyle);
-				}
-			});
-		};
-
-		const styleObserver: StyleObserver = new StyleObserver({
-			callback: insert,
-		});
-		const targetNode: HTMLHeadElement = document.head;
-		styleObserver.startObserving(targetNode);
-		insert(headStyles);
-
-		return () => styleObserver.stopObserving();
-	}, []);
+	const { ref } = useStyles();
 
 	const singleValue = !properties.isMulti && props.options.find(item => item.value === props.value);
 	let value = properties.isMulti ? props.value : singleValue;
 	const onChange = params => {
 		if (!props.onChange) return;
 		const isMultiValues = properties?.isMulti;
-		if (!isMultiValues) {
-			props.onChange({
-				target: {
-					value,
-					name: props.name,
-				},
-				currentTarget: {
-					value,
-					name: props.name,
-				},
-			});
-			return;
-		}
+		const values = isMultiValues && params.map(selectedItem => selectedItem.value);
+		const value = isMultiValues ? values : params.value;
+		const { name } = props;
 
-		const values = params.map(selectedItem => selectedItem.value);
+		const target = {
+			value,
+			name,
+		};
+
 		props.onChange({
-			target: {
-				value: values,
-				name: props.name,
-			},
-			currentTarget: {
-				value: values,
-				name: props.name,
-			},
+			target,
+			currentTarget: target,
 		});
 	};
 

--- a/src/modules/form/react-select/ts/use-styles.ts
+++ b/src/modules/form/react-select/ts/use-styles.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StyleObserver } from './observer';
+
+export function useStyles() {
+	const ref = React.useRef(null);
+
+	React.useEffect(() => {
+		if (!ref.current) return;
+		const host = ref.current.getRootNode()?.host;
+		if (!host) console.warn('is not inside a web component');
+		if (!host.shadowRoot.insertedStyles) host.shadowRoot.insertedStyles = new Set();
+
+		const headStyles = document.head.querySelectorAll('style[data-emotion]');
+		// The callback name is used because it is the property parameter of the StyleObserver class
+		const callback = (nodes: HTMLElement[] | NodeList) => {
+			const insertedStyles = new Set();
+			nodes.forEach(node => {
+				const styleContent = node?.textContent;
+				if (!(node instanceof HTMLStyleElement) || insertedStyles.has(styleContent)) return;
+
+				const clonedStyle = node.cloneNode(true);
+				host.shadowRoot.appendChild(clonedStyle);
+				insertedStyles.add(styleContent);
+			});
+		};
+
+		const styleObserver: StyleObserver = new StyleObserver({ callback });
+		const targetNode: HTMLHeadElement = document.head;
+		styleObserver.startObserving(targetNode);
+		callback(headStyles);
+
+		return () => styleObserver.stopObserving();
+	}, [ref.current]);
+
+	return { ref };
+}


### PR DESCRIPTION
## Improved Multiple Selection Handling in Component Select 👐

## Description

This PR introduces a significant enhancement to the Select component of the pragmate-ui library. The component now has the ability to handle multiple selection of options, providing greater flexibility and functionality for users.

The enhancement focuses on the `onChange` function, which can now handle and send multiple selected options. This is especially useful in situations where users may need to select multiple options in a Select, such as selecting multiple categories, tags, etc.

Here is the relevant code:

````ts
const onChange = params => {
  if (!props.onChange) return;
  
  const isMultiValues = properties?.isMulti;
  
  if (!isMultiValues) {
    props.onChange({
      target: {
        value,
        name: props.name,
      },
      currentTarget: {
        value,
        name: props.name,
      },
    });
    return;
  }
  
  const values = params.map(selectedItem => selectedItem.value);
  
  props.onChange({
    target: {
      value: values,
      name: props.name,
    },
    currentTarget: {
      value: values,
      name: props.name,
    },
  });
};
````

This setting obviously implied to give full compatibility to the MultiValue case so I also need to add an extra validation since the `value` property is sent differently if the case is singleValue or not.

```ts
const singleValue = !properties.isMulti && props.options.find(item => item.value === props.value);
let value = properties.isMulti ? props.value : singleValue;
```


### For more info about the MultiSelect functionality:

[Click here!](https://react-select.com/advanced#sortable-multiselect)