### PR TITLE
Add wise-form docs module

### DIFF
--- a/docs/modules/pages/wise-form/module.json
+++ b/docs/modules/pages/wise-form/module.json
@@ -1,0 +1,23 @@
+{
+  "name": "wise-form",
+  "widget": {
+    "route": "/wise-form",
+    "is": "page",
+    "layout": "pui-docs-layout",
+    "scss": {
+      "path": "/scss",
+      "files": ["*"]
+    },
+    "ts": {
+      "path": "/ts",
+      "files": ["*"]
+    },
+    "mdx": {
+      "path": "/ts",
+      "files": ["*"]
+    },
+    "element": {
+      "name": "pui-wise-form-page"
+    }
+  }
+}

--- a/docs/modules/pages/wise-form/ts/controller.ts
+++ b/docs/modules/pages/wise-form/ts/controller.ts
@@ -1,0 +1,14 @@
+import { PageReactWidgetController } from '@beyond-js/react-18-widgets/page';
+import { StoreManager } from './store';
+import { View } from './views';
+
+export /*bundle*/ class Controller extends PageReactWidgetController {
+  #store: StoreManager;
+  createStore() {
+    this.#store = new StoreManager();
+    return this.#store;
+  }
+  get Widget() {
+    return View;
+  }
+}

--- a/docs/modules/pages/wise-form/ts/store.ts
+++ b/docs/modules/pages/wise-form/ts/store.ts
@@ -1,0 +1,3 @@
+import type { IWidgetStore } from '@beyond-js/widgets/controller';
+
+export class StoreManager implements IWidgetStore {}

--- a/docs/modules/pages/wise-form/ts/views/es/index.mdx
+++ b/docs/modules/pages/wise-form/ts/views/es/index.mdx
@@ -1,0 +1,189 @@
+# Wise Form Wizard
+
+## Concepto Base del Wizard
+
+- **Input/Output**: El usuario crea o edita un formulario complejo desde la UI y el resultado es un objeto JSON.
+- **Modularidad**: Cada paso del wizard representa una sección del JSON (configuración general, observers, fields, wrappers, formulas, etc.).
+- **Componentización**: Cada tipo de elemento (field, wrapper, observer, button, etc.) se representa como un componente configurable.
+
+## Estructura General del Wizard
+
+1. **Paso 1: Configuración general del formulario**
+   - `name` (string)
+   - `template` (array de layout)
+   - `observers` (array opcional)
+   - Componente sugerido: `GeneralConfigForm.tsx`
+2. **Paso 2: Gestión de elementos**
+   - Permite agregar dinámicamente campos (`field`), contenedores (`wrapper`), fórmulas (`formula`), botones y más.
+   - Cada ítem tiene un modal de edición con campos según su tipo.
+3. **Paso 3: Previsualización y Exportación**
+   - Se muestra el JSON resultante con opciones para copiar, descargar o guardar.
+   - Validación de estructura.
+
+## Tipos de Elementos Soportados
+
+| Tipo     | Subtipos o Props comunes                                         |
+| -------- | ---------------------------------------------------------------- |
+| `field`  | text, number, select, checkbox, date, currency                    |
+| `wrapper`| div, modal, collapsible, tooltip                                  |
+| `observer` | basic, base-conditional, comparison, value-conditions            |
+| `button` | onClick, variant, dependencias                                    |
+| `template`| Array de grids / layouts                                         |
+
+Cada uno tendrá una UI dinámica basada en un esquema de propiedades editable.
+
+## Pasos Detallados para Implementar
+
+1. **Setup del proyecto**
+   - Estructura base React con Sass.
+   - Definir tipado de cada componente JSON.
+2. **Crear modelo de datos centralizado**
+
+```ts
+interface WizardForm {
+  name: string;
+  template: (string | [number, string])[];
+  observers: ObserverConfig[];
+  fields: FieldItem[];
+}
+```
+
+3. **Construcción de UI por pasos**
+   - Configuración inicial (nombre, layout, observers).
+   - Editor de grid para `template`.
+   - Editor de observers y dependencias.
+   - Editor de campos y estructuras con drag & drop.
+   - Botón para agregar elementos y modal dinámico por tipo.
+   - Previsualización y acciones de exportación.
+
+## Ejemplo de flujo en el Wizard
+
+1. Definir nombre y layout de columnas.
+2. Agregar un `field` tipo text llamado `titulo` con label **Título**.
+3. Agregar un `wrapper` tipo `collapsible` llamado `datosEditoriales` y dentro varios fields.
+4. Agregar un `observer` para calcular un campo.
+5. Visualizar y guardar.
+
+## Componentes UI requeridos
+
+- `WizardStepper`: navegación entre pasos.
+- `FormItemEditor`: editor modal para cualquier item JSON.
+- `TemplateGridEditor`: editor visual de layout.
+- `ObserverEditor`: editor de fórmulas con validación.
+- `FieldPreview`: render del JSON resultante.
+- `DynamicForm`: componente que renderiza formularios desde esquemas JSON.
+
+## Schemas de Propiedades por Tipo de Item
+
+### 1. `field` – Campos básicos
+
+```ts
+ type FieldType = 'text' | 'number' | 'select' | 'checkbox' | 'date' | 'currency' | 'wiseCheckbox';
+
+ interface FieldConfig {
+   type: FieldType;
+   name: string;
+   label?: string;
+   disabled?: boolean;
+   value?: any;
+   className?: string;
+   identifier?: string;
+   colSpan?: string;
+   options?: any; // solo si type = select
+   properties?: string[]; // ["checked", "loading"]
+   onCheck?: Callback[];
+   onClick?: Callback[];
+ }
+```
+
+### 2. `wrapper` – Contenedores de campos
+
+```ts
+ type WrapperControl = 'div' | 'modal' | 'collapsible' | 'tooltip';
+
+ interface WrapperConfig {
+   type: 'wrapper';
+   control: WrapperControl;
+   name: string;
+   title?: string;
+   template?: (string | [number, string])[];
+   className?: string;
+   fields: ItemConfig[];
+   properties?: string[];
+   style?: Record<string, string>;
+ }
+```
+
+### 3. `observer` – Fórmulas
+
+```ts
+ type ObserverType = 'basic' | 'base-conditional' | 'comparison' | 'value-conditions';
+
+ interface ObserverConfig {
+   name: string;
+   type: ObserverType;
+   formula: string | ConditionalFormula;
+   fields?: string[];
+   observers?: string[];
+ }
+
+ interface ConditionalFormula {
+   base: string;
+   fields: string[];
+   conditions: Array<{
+     condition: 'equal' | 'hasValue' | 'empty';
+     value?: any;
+     fields: string[];
+     formula: string;
+   }>;
+ }
+```
+
+### 4. `button`
+
+```ts
+ interface ButtonConfig {
+   type: 'button';
+   name: string;
+   label: string;
+   variant?: 'primary' | 'secondary';
+   className?: string;
+   disabled?: boolean;
+   onClick?: Callback[];
+   dependentOn?: Dependency[];
+   properties?: string[];
+ }
+```
+
+### 5. Estructura genérica
+
+```ts
+ type ItemConfig = FieldConfig | WrapperConfig | ButtonConfig;
+
+ interface Callback {
+   to: string;
+   property?: string;
+   value?: any;
+   callback?: string;
+   field?: string;
+   valueItem?: string;
+   wrapperTo?: string;
+   type?: 'reset';
+ }
+
+ interface Dependency {
+   callback: string;
+   field: string;
+   property: string;
+   validations?: Validation[];
+   callbacksFulfilled?: Callback[];
+   callbacksFailed?: Callback[];
+ }
+
+ interface Validation {
+   field: string;
+   condition: 'theresAValueWith' | string;
+   value: any;
+   property: string;
+ }
+```

--- a/docs/modules/pages/wise-form/ts/views/index.tsx
+++ b/docs/modules/pages/wise-form/ts/views/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Docs from './es/index.mdx';
+
+export /*bundle*/ function View() {
+  return (
+    <div className="page__container">
+      <Docs />
+    </div>
+  );
+}

--- a/docs/modules/pages/wise-form/tsconfig.json
+++ b/docs/modules/pages/wise-form/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "es2020",
+    "target": "es2018",
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Node",
+    "jsx": "react"
+  }
+}


### PR DESCRIPTION
## Summary
- add new `wise-form` docs page module under `docs/modules/pages`
- describe wizard concept and property schemas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68537084d5ec832bba17ef6bc08c889e